### PR TITLE
Don't resolve name when building table path

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -1796,7 +1796,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           if (tbl.getSd().getLocation() == null
               || tbl.getSd().getLocation().isEmpty()) {
             tblPath = wh.getDefaultTablePath(
-                ms.getDatabase(tbl.getCatName(), tbl.getDbName()), tbl.getTableName());
+                ms.getDatabase(tbl.getCatName(), tbl.getDbName(), false), tbl.getTableName());
           } else {
             if (!isExternal(tbl) && !MetaStoreUtils.isNonNativeTable(tbl)) {
               LOG.warn("Location: " + tbl.getSd().getLocation()

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -318,7 +318,7 @@ class MetaStoreDirectSql {
     }
   }
 
-  public Database getDatabase(String catName, String dbName) throws MetaException{
+  public Database getDatabase(String catName, String dbName, boolean resolveHostname) throws MetaException{
     Query queryDbSelector = null;
     Query queryDbParams = null;
     try {
@@ -373,7 +373,11 @@ class MetaStoreDirectSql {
       }
       Database db = new Database();
       db.setName(extractSqlString(dbline[1]));
-      db.setLocationUri(serviceDiscoveryClient.resolveLocationURI(extractSqlString(dbline[2])));
+      if (resolveHostname) {
+        db.setLocationUri(serviceDiscoveryClient.resolveLocationURI(extractSqlString(dbline[2])));
+      } else {
+        db.setLocationUri(extractSqlString(dbline[2]));
+      }
       db.setDescription(extractSqlString(dbline[3]));
       db.setOwnerName(extractSqlString(dbline[4]));
       String type = extractSqlString(dbline[5]);

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -191,6 +191,18 @@ public interface RawStore extends Configurable {
       throws NoSuchObjectException;
 
   /**
+   * Get a database.
+   * @param catalogName catalog the database is in.
+   * @param name name of the database.
+   * @param resolveHostname true to resolve the internal hostname
+   * @return the database.
+   * @throws NoSuchObjectException if no such database exists.
+   */
+  Database getDatabase(String catalogName, String name, boolean resolveHostname)
+      throws NoSuchObjectException;
+
+
+  /**
    * Drop a database.
    * @param catalogName catalog the database is in.
    * @param dbname name of the database.

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -764,12 +764,17 @@ public class CachedStore implements RawStore, Configurable {
 
   @Override
   public Database getDatabase(String catName, String dbName) throws NoSuchObjectException {
+    return getDatabase(catName, dbName, true);
+  }
+
+  @Override
+  public Database getDatabase(String catName, String dbName, boolean resolveHostname) throws NoSuchObjectException {
     if (!sharedCache.isDatabaseCachePrewarmed()) {
       return rawStore.getDatabase(catName, dbName);
     }
     dbName = dbName.toLowerCase();
     Database db = sharedCache.getDatabaseFromCache(StringUtils.normalizeIdentifier(catName),
-            StringUtils.normalizeIdentifier(dbName));
+        StringUtils.normalizeIdentifier(dbName));
     if (db == null) {
       throw new NoSuchObjectException();
     }

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -192,6 +192,11 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
+  public Database getDatabase(String catName, String dbName, boolean resolveHostname) throws NoSuchObjectException {
+    return objectStore.getDatabase(catName, dbName, resolveHostname);
+  }
+
+  @Override
   public boolean dropDatabase(String catName, String dbName)
       throws NoSuchObjectException, MetaException {
     return objectStore.dropDatabase(catName, dbName);

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -177,13 +177,16 @@ public class DummyRawStoreForJdoConnection implements RawStore {
 
   @Override
   public Database getDatabase(String catName, String name) throws NoSuchObjectException {
+    return null;
+  }
 
+  @Override
+  public Database getDatabase(String catName, String name, boolean resolveHostname) throws NoSuchObjectException {
     return null;
   }
 
   @Override
   public boolean dropDatabase(String catName, String dbname) throws NoSuchObjectException, MetaException {
-
     return false;
   }
 


### PR DESCRIPTION
When building the location for managed table, the sd.location field is null and the metastore uses the path of the database to construct the path of the table.

In this case we need to avoid doing the hostname resolution, otherwise we'll end up with the IP in the database. 